### PR TITLE
Closed the open file stream

### DIFF
--- a/PSYaml/PSYaml.psd1
+++ b/PSYaml/PSYaml.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSYaml.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.2'
+ModuleVersion = '1.0.3'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/PSYaml/Public/ConvertFrom-Yaml.ps1
+++ b/PSYaml/Public/ConvertFrom-Yaml.ps1
@@ -38,17 +38,26 @@ function ConvertFrom-Yaml {
 BEGIN { }
 PROCESS
     {
-        If($Path){
-            $streamReader = [System.IO.File]::OpenText($Path)
+        try {
+            If($Path) {
+                $streamReader = [System.IO.File]::OpenText($Path)
+            }
+            Else {
+                $streamReader = new-object System.IO.StringReader([string]$yamlString)
+            }
+
             $yamlStream = New-Object YamlDotNet.RepresentationModel.YamlStream
             $yamlStream.Load([System.IO.TextReader]$streamReader)
             ConvertFrom-YAMLDocument ($yamlStream.Documents[0])
         }
-        Else{
-            $stringReader = new-object System.IO.StringReader([string]$yamlString)
-            $yamlStream = New-Object YamlDotNet.RepresentationModel.YamlStream
-            $yamlStream.Load([System.IO.TextReader]$stringReader)
-            ConvertFrom-YAMLDocument ($yamlStream.Documents[0])
+        Catch {
+            Write-Error $_
+        }
+        Finally {
+            if ($streamReader.Basestream -ne $null)
+            {
+                $streamReader.Close()
+            }
         }
     }
 END {}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Author: Phil-Factor, Brian Marsh
 ## Release Notes
 |  Version  | Change Log                                                        |
 | :-------: | ----------------------------------------------------------------- |
+|  1.0.3    | Closed the open YAML file if error occurs in it during parsing    |
 |  1.0.2    | Reformated several sections for readability, added pester tests   |
 |  1.0.1    | Converted single psm1 file to multiple public/private functions   |
 


### PR DESCRIPTION
1) When convertfrom-yaml is being used on a yaml file and if an error
occurs while parsing it, then the file cannot be modified until the
powershell session is closed. Fixed it using $streamReader.Close()

2) Extracted the common code in the if and else section of
convertfrom-yaml to make code more readable.